### PR TITLE
Migrate skeleton project to current Elixir release

### DIFF
--- a/elixir/.formatter.exs
+++ b/elixir/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/elixir/.gitignore
+++ b/elixir/.gitignore
@@ -1,5 +1,24 @@
-/_build
-/cover
-/deps
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+kata-*.tar
+

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -8,15 +8,15 @@ use Mix.Config
 # if you want to provide default values for your application for
 # 3rd-party users, it should be done in your "mix.exs" file.
 
-# You can configure for your application as:
+# You can configure your application as:
 #
 #     config :kata, key: :value
 #
-# And access this configuration in your application as:
+# and access this configuration in your application as:
 #
 #     Application.get_env(:kata, :key)
 #
-# Or configure a 3rd-party app:
+# You can also configure a 3rd-party app:
 #
 #     config :logger, level: :info
 #

--- a/elixir/lib/kata.ex
+++ b/elixir/lib/kata.ex
@@ -1,2 +1,18 @@
 defmodule Kata do
+  @moduledoc """
+  Documentation for Kata.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> Kata.hello
+      :world
+
+  """
+  def hello do
+    :world
+  end
 end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -1,32 +1,28 @@
-defmodule Kata.Mixfile do
+defmodule Kata.MixProject do
   use Mix.Project
 
   def project do
-    [app: :kata,
-     version: "0.0.1",
-     elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps]
+    [
+      app: :kata,
+      version: "0.1.0",
+      elixir: "~> 1.6",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
+  # Run "mix help compile.app" to learn about applications.
   def application do
-    [applications: [:logger]]
+    [
+      extra_applications: [:logger]
+    ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
+  # Run "mix help deps" to learn about dependencies.
   defp deps do
-    []
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+    ]
   end
 end

--- a/elixir/test/kata_test.exs
+++ b/elixir/test/kata_test.exs
@@ -2,7 +2,7 @@ defmodule KataTest do
   use ExUnit.Case
   doctest Kata
 
-  test "the truth" do
-    assert 42 + 1 == 42
+  test "greets the world" do
+    assert Kata.hello() == :world
   end
 end

--- a/elixir/test/kata_test.exs
+++ b/elixir/test/kata_test.exs
@@ -3,6 +3,6 @@ defmodule KataTest do
   doctest Kata
 
   test "greets the world" do
-    assert Kata.hello() == :world
+    assert Kata.hello() == :universe
   end
 end


### PR DESCRIPTION
The original skeleton is two years old and 4 major releases of Elixir and its tooling have come out since. Time to update to the current Elixir release (1.6.x).