### PR TITLE
Update java projects dec 2018

### DIFF
--- a/java/assert_j/README.md
+++ b/java/assert_j/README.md
@@ -16,8 +16,8 @@ Open as prexisting project in your favorite IDE and choose between gradle or mav
 To execute the tests either run `gradle test`, `mvn test` or run the tests from the IDE you are using
 
 ## Test Libraries Available from the Get-Go
-- JUnit 5.3.1
-- AssertJ 3.9.1
+- JUnit 5.3.2
+- AssertJ 3.11.1
 
 This repo was tested with eclipse and idea, if you encounter problems please open a issue or send a pull request.
 

--- a/java/assert_j/build.gradle
+++ b/java/assert_j/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 
-sourceCompatibility = 1.10
+sourceCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -13,8 +13,8 @@ test {
 
 dependencies {
     testCompile(
-            'org.junit.jupiter:junit-jupiter-api:5.3.1',
-            'org.assertj:assertj-core:3.10.0'
+            'org.junit.jupiter:junit-jupiter-api:5.3.2',
+            'org.assertj:assertj-core:3.11.1'
     )
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.1')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.2')
 }

--- a/java/assert_j/pom.xml
+++ b/java/assert_j/pom.xml
@@ -8,32 +8,32 @@
     <version>1.0</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.10</maven.compiler.source>
-        <maven.compiler.target>1.10</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.10.0</version>
+            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
+            <version>5.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -57,7 +57,7 @@
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.3.1</version>
+                        <version>5.3.2</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/java/assert_j/src/test/java/ThingTest.java
+++ b/java/assert_j/src/test/java/ThingTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ThingTest {
 
     @Test
-    public void it_should_call_for_action() {
+    void it_should_call_for_action() {
         Thing thing = new Thing();
         String value = thing.callForAction();
         assertThat(value).isEqualTo("Food");

--- a/java/hamcrest/README.md
+++ b/java/hamcrest/README.md
@@ -17,7 +17,7 @@ Open as prexisting project in your favorite IDE and choose between gradle or mav
 To execute the tests either run `gradle test`, `mvn test` or run the tests from the IDE you are using
 
 ## Test Libraries Available from the Get-Go
-- JUnit 5.3.1
+- JUnit 5.3.2
 - Hamcrest 1.3
 
 This repo was tested with eclipse and idea, if you encounter problems please open a issue or send a pull request.

--- a/java/hamcrest/build.gradle
+++ b/java/hamcrest/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'idea'
 
-sourceCompatibility = 1.10
+sourceCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -14,8 +14,8 @@ test {
 
 dependencies {
     testCompile(
-            'org.junit.jupiter:junit-jupiter-api:5.3.1',
+            'org.junit.jupiter:junit-jupiter-api:5.3.2',
             'org.hamcrest:hamcrest-all:1.3'
     )
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.1')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.2')
 }

--- a/java/hamcrest/pom.xml
+++ b/java/hamcrest/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.10</maven.compiler.source>
-        <maven.compiler.target>1.10</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
@@ -21,19 +21,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
+            <version>5.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -57,7 +57,7 @@
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.3.1</version>
+                        <version>5.3.2</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/java/hamcrest/src/test/java/ThingTest.java
+++ b/java/hamcrest/src/test/java/ThingTest.java
@@ -4,11 +4,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-
 public class ThingTest {
 
     @Test
-    public void it_should_call_for_action() {
+    void it_should_call_for_action() {
         Thing thing = new Thing();
         String value = thing.callForAction();
         assertThat(value, is(equalTo("Food")));

--- a/java/junit5/README.md
+++ b/java/junit5/README.md
@@ -16,7 +16,7 @@ Open as prexisting project in your favorite IDE and choose between gradle or mav
 To execute the tests either run `gradle test`, `mvn test` or run the tests from the IDE you are using
 
 ## Test Libraries Available from the Get-Go
-- JUnit 5.3.1
+- JUnit 5.3.2
 
 This repo was tested with eclipse and idea, if you encounter problems please open a issue or send a pull request.
 

--- a/java/junit5/build.gradle
+++ b/java/junit5/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'idea'
 
-sourceCompatibility = 1.10
+sourceCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -13,6 +13,6 @@ test {
 }
 
 dependencies {
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.3.1")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.1")
+    testCompile("org.junit.jupiter:junit-jupiter-api:5.3.2")
+    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.2")
 }

--- a/java/junit5/pom.xml
+++ b/java/junit5/pom.xml
@@ -8,26 +8,26 @@
     <version>1.0</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.10</maven.compiler.source>
-        <maven.compiler.target>1.10</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
+            <version>5.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -51,7 +51,7 @@
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.3.1</version>
+                        <version>5.3.2</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/java/junit5/src/test/java/ThingTest.java
+++ b/java/junit5/src/test/java/ThingTest.java
@@ -1,13 +1,13 @@
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ThingTest {
 
     @Test
-    public void it_should_call_for_action() {
+    void it_should_call_for_action() {
         Thing thing = new Thing();
         String value = thing.callForAction();
-        assertEquals(value, "Food");
+        assertEquals("Food", value);
     }
 }

--- a/java/mockito/README.md
+++ b/java/mockito/README.md
@@ -16,8 +16,8 @@ Open as prexisting project in your favorite IDE and choose between gradle or mav
 To execute the tests either run `gradle test`, `mvn test` or run the tests from the IDE you are using
 
 ## Test Libraries Available from the Get-Go
-- JUnit 5.3.1
-- Mockito 2.15.0
+- JUnit 5.3.2
+- Mockito 2.23.4
 
 This repo was tested with eclipse and idea, if you encounter problems please open a issue or send a pull request.
 

--- a/java/mockito/build.gradle
+++ b/java/mockito/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'idea'
 
-sourceCompatibility = 1.10
+sourceCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -14,8 +14,8 @@ test {
 
 dependencies {
     testCompile(
-            'org.junit.jupiter:junit-jupiter-api:5.3.1',
-            'org.mockito:mockito-core:2.18.3'
+            'org.junit.jupiter:junit-jupiter-api:5.3.2',
+            'org.mockito:mockito-core:2.23.4'
     )
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.1')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.2')
 }

--- a/java/mockito/pom.xml
+++ b/java/mockito/pom.xml
@@ -8,32 +8,32 @@
     <version>1.0</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.10</maven.compiler.source>
-        <maven.compiler.target>1.10</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.18.3</version>
+            <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
+            <version>5.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -57,7 +57,7 @@
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.3.1</version>
+                        <version>5.3.2</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/java/mockito/src/test/java/ThingTest.java
+++ b/java/mockito/src/test/java/ThingTest.java
@@ -1,13 +1,13 @@
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ThingTest {
 
     @Test
-    public void it_should_call_for_action() {
+    void it_should_call_for_action() {
         Thing thing = new Thing();
         String value = thing.callForAction();
-        assertEquals(value, "Food");
+        assertEquals("Food", value);
     }
 }

--- a/java/truth/README.md
+++ b/java/truth/README.md
@@ -16,8 +16,8 @@ Open as prexisting project in your favorite IDE and choose between gradle or mav
 To execute the tests either run `gradle test`, `mvn test` or run the tests from the IDE you are using
 
 ## Test Libraries Available from the Get-Go
-- JUnit 5.3.1
-- Google Truth 0.39
+- JUnit 5.3.2
+- Google Truth 0.42
 
 This repo was tested with eclipse and idea, if you encounter problems please open a issue or send a pull request.
 

--- a/java/truth/build.gradle
+++ b/java/truth/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'idea'
 
-sourceCompatibility = 1.10
+sourceCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -14,8 +14,8 @@ test {
 
 dependencies {
     testCompile(
-            'org.junit.jupiter:junit-jupiter-api:5.3.1',
-            'com.google.truth:truth:0.41'
+            'org.junit.jupiter:junit-jupiter-api:5.3.2',
+            'com.google.truth:truth:0.42'
     )
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.1')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.2')
 }

--- a/java/truth/pom.xml
+++ b/java/truth/pom.xml
@@ -8,32 +8,32 @@
     <version>1.0</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.10</maven.compiler.source>
-        <maven.compiler.target>1.10</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
-            <version>0.41</version>
+            <version>0.42</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
+            <version>5.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -57,7 +57,7 @@
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.3.1</version>
+                        <version>5.3.2</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/java/truth/src/test/java/ThingTest.java
+++ b/java/truth/src/test/java/ThingTest.java
@@ -1,13 +1,13 @@
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class ThingTest {
 
     @Test
-    public void it_should_call_for_action() {
+    void it_should_call_for_action() {
         Thing thing = new Thing();
         String value = thing.callForAction();
-        assertEquals(value, "Food");
+        assertThat(value).isEqualTo("Food");
     }
 }


### PR DESCRIPTION
hello,

I updated the java projects to:
* use java 11
* use latest junit5 (5.3.2)
* use the latest versions of assertj, mockito and truth.
* use package private test example (afaik thats the junit5 convention)
* flipped arguments of assertEquals in the test examples as they were wrong