### PR TITLE
Update gradle wrapper version used in kotlintest

### DIFF
--- a/kotlin/kotlintest/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/kotlintest/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip


### PR DESCRIPTION
Without this, running `./gradlew idea`, or even just `./gradlew --version`, produced:
```
FAILURE: Build failed with an exception.
* What went wrong:
Could not determine java version from '10.0.1'.
```
From https://stackoverflow.com/questions/54358107/gradle-could-not-determine-java-version-from-11-0-2, determined the problem was that the gradle wrapper was not compatible with my Java version. Copied the newer 4.10 distribution url from the java/junit4 directory, and voila, now it all works tickety boo.

Not sure if we should be using an even newer gradle distribution (seems 5 is a thing), and whether to update the kotlin/spek/ distribution too..?