### PR TITLE
Add .gitignore for kotlin/kotlintest

### DIFF
--- a/kotlin/kotlintest/.gitignore
+++ b/kotlin/kotlintest/.gitignore
@@ -1,0 +1,9 @@
+/bin/
+/out/
+.gradle
+build
+.classpath
+.settings
+.project
+*.iws
+*.ipr

--- a/kotlin/kotlintest/.gitignore
+++ b/kotlin/kotlintest/.gitignore
@@ -7,3 +7,4 @@ build
 .project
 *.iws
 *.ipr
+.kotlintest


### PR DESCRIPTION
Copied from java/junit4 project gitignore, which covers all the random files I end up with after running existing kotlin tests from IntelliJ.