### PR TITLE
Update gradlew & kotlin distributions in kotlin/kotlintest

### DIFF
--- a/kotlin/kotlintest/build.gradle
+++ b/kotlin/kotlintest/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.60'
+    ext.kotlin_version = '1.3.41'
 
     repositories {
         jcenter()
@@ -17,6 +17,6 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
-        testCompile 'io.kotlintest:kotlintest:2.0.7'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    testImplementation 'io.kotlintest:kotlintest:2.0.7'
 }

--- a/kotlin/kotlintest/build.gradle
+++ b/kotlin/kotlintest/build.gradle
@@ -16,7 +16,11 @@ repositories {
     jcenter()
 }
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
-    testImplementation 'io.kotlintest:kotlintest:2.0.7'
+    testImplementation 'io.kotlintest:kotlintest-runner-junit5:3.4.0'
 }

--- a/kotlin/kotlintest/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/kotlintest/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip

--- a/kotlin/kotlintest/src/test/kotlin/ThingBehaviorSpec.kt
+++ b/kotlin/kotlintest/src/test/kotlin/ThingBehaviorSpec.kt
@@ -1,4 +1,4 @@
-import io.kotlintest.matchers.shouldBe
+import io.kotlintest.shouldBe
 import io.kotlintest.specs.BehaviorSpec
 
 class ThingBehaviorSpec : BehaviorSpec() { init {

--- a/kotlin/kotlintest/src/test/kotlin/ThingStringSpec.kt
+++ b/kotlin/kotlintest/src/test/kotlin/ThingStringSpec.kt
@@ -1,9 +1,9 @@
-import io.kotlintest.matchers.shouldBe
-import io.kotlintest.properties.forAll
-import io.kotlintest.properties.headers
-import io.kotlintest.properties.row
-import io.kotlintest.properties.table
+import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
+import io.kotlintest.tables.forAll
+import io.kotlintest.tables.headers
+import io.kotlintest.tables.row
+import io.kotlintest.tables.table
 
 class ThingStringSpec : StringSpec() { init {
     "it should callForAction" {


### PR DESCRIPTION
These changes make the build compatible with JDK 9 or higher.

(Without these changes I could only get the tests to run by setting jdk back to 1.8 via:
`PATH=/Library/Java/JavaVirtualMachines/jdk1.8.0_211.jdk/Contents/Home/bin/:${PATH} ./gradlew clean test`)