### PR TITLE
Provide D templates

### DIFF
--- a/d/silly/.gitignore
+++ b/d/silly/.gitignore
@@ -1,0 +1,15 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/kata
+kata.so
+kata.dylib
+kata.dll
+kata.a
+kata.lib
+kata-test-*
+*.exe
+*.o
+*.obj
+*.lst

--- a/d/silly/README.md
+++ b/d/silly/README.md
@@ -1,0 +1,17 @@
+d/silly setup
+==========
+
+This is a simple bootstrap project for D with silly. silly is a no-nonsense test runner for the D programming language. Instead of re-inventing the wheel and adding more and more levels of abstraction it just works, requiring as little effort from the programmer as possible. 
+
+Using DUB just run
+
+```
+dub test
+
+```
+
+If you want to change silly's options (e.g. run only certain tests, change number of threads, …), this might help
+```
+dub test -- --help
+```
+(note the `--` before(!) `--help`)

--- a/d/silly/dub.json
+++ b/d/silly/dub.json
@@ -1,0 +1,10 @@
+{
+	"authors": [
+		"Matthias Vill"
+	],
+	"dependencies": {
+		"silly": "*"
+	},
+	"description": "A kata in D using silly.",
+	"name": "kata"
+}

--- a/d/silly/source/app.d
+++ b/d/silly/source/app.d
@@ -1,0 +1,7 @@
+import std.stdio;
+
+void main()
+{
+	writeln("Edit source/kata.d to implement your project.");
+	writeln("Edit source/app.d to implement main() to be used outside of unit-tests.");
+}

--- a/d/silly/source/kata.d
+++ b/d/silly/source/kata.d
@@ -1,0 +1,15 @@
+module kata;
+
+@("Dummy test") unittest
+{
+    auto kata = new Kata();
+    assert(true == false, "true is false");
+}
+
+/** 
+ * A Kata
+ */
+class Kata
+{
+
+}

--- a/d/unit-threaded/.gitignore
+++ b/d/unit-threaded/.gitignore
@@ -1,0 +1,16 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/kata
+kata.so
+kata.dylib
+kata.dll
+kata.a
+kata.lib
+kata-test-*
+*.exe
+*.o
+*.obj
+*.lst
+bin/

--- a/d/unit-threaded/README.md
+++ b/d/unit-threaded/README.md
@@ -1,0 +1,19 @@
+d/unit-threaded setup
+==========
+
+This is a simple bootstrap project for D with unit-threaded. unit-threaded is an advanced multi-threaded unit testing framework with minimal to no boilerplate using built-in unittest blocks.
+
+Using DUB just run
+
+```
+dub test
+
+```
+
+If you want to change unit-threaded's options (e.g. run only certain tests, single-threaded execution, …), this might help
+```
+dub test -- --help
+```
+(note the `--` before(!) `--help`)
+
+You may also want to visit [unit-threaded's GitHub-repo](https://github.com/atilaneves/unit-threaded) for examples on how to use fluent assertions and mocks.

--- a/d/unit-threaded/dub.json
+++ b/d/unit-threaded/dub.json
@@ -1,0 +1,20 @@
+{
+	"authors": [
+		"Matthias Vill"
+	],
+	"description": "A kata in D using unit-threaded.",
+	"name": "kata",
+    "configurations": [
+        { "name": "executable" },
+        {
+            "name": "unittest",
+            "targetType": "executable",
+            "preBuildCommands": ["$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"],
+            "mainSourceFile": "bin/ut.d",
+            "excludedSourceFiles": ["source/app.d"],
+            "dependencies": {
+                "unit-threaded": "*"
+            }
+        }
+    ]
+}

--- a/d/unit-threaded/source/app.d
+++ b/d/unit-threaded/source/app.d
@@ -1,0 +1,7 @@
+import std.stdio;
+
+void main()
+{
+	writeln("Edit source/kata.d to implement your project.");
+	writeln("Edit source/app.d to implement main() to be used outside of unit-tests.");
+}

--- a/d/unit-threaded/source/kata.d
+++ b/d/unit-threaded/source/kata.d
@@ -1,0 +1,24 @@
+module kata;
+
+version (unittest)
+{
+    import unit_threaded;
+}
+else
+{
+    private enum ShouldFail;
+} // so production builds compile
+
+@("Dummy test") unittest
+{
+    auto kata = new Kata();
+    true.should == false;
+}
+
+/** 
+ * A Kata
+ */
+class Kata
+{
+
+}


### PR DESCRIPTION
Provide templates to do Katas in D. Included are templates using `silly` (improved test-runner only) and `unit-threaded` (adding assertions, mocks, … and improved test-runner).