### PR TITLE
Upgrade versions of java/junit5 and java/jqwik

### DIFF
--- a/java/jqwik/README.md
+++ b/java/jqwik/README.md
@@ -16,8 +16,8 @@ Open as preexisting project in your favorite IDE and choose between gradle or ma
 To execute the tests either run `gradle test`, `mvn test` or run the tests from the IDE you are using.
 
 ## Test Libraries Available from the Get-Go
-- jqwik 1.1.1
-- assertJ 3.11.1
+- jqwik 1.2.1
+- assertJ 3.13.2
 
 This repo was tested with eclipse and idea, if you encounter problems please open a issue or send a pull request.
 

--- a/java/jqwik/build.gradle
+++ b/java/jqwik/build.gradle
@@ -7,9 +7,9 @@ compileTestJava {
     options.compilerArgs += '-parameters'
 }
 
-ext.junitPlatformVersion = '1.3.1'
-ext.junitJupiterVersion = '5.3.1'
-ext.jqwikVersion = '1.1.1'
+ext.junitPlatformVersion = '1.5.2'
+ext.junitJupiterVersion = '5.5.2'
+ext.jqwikVersion = '1.2.1'
 
 repositories {
     mavenCentral()
@@ -34,10 +34,7 @@ dependencies {
     testCompile "net.jqwik:jqwik:${jqwikVersion}"
 
     // Fluent assertions library
-    testCompile("org.assertj:assertj-core:3.11.1")
-
-    // For Jupiter tests and also necessary to work around some IntelliJ bugs
-    testCompile("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
+    testCompile("org.assertj:assertj-core:3.13.2")
 
 }
 

--- a/java/jqwik/pom.xml
+++ b/java/jqwik/pom.xml
@@ -11,10 +11,10 @@
             <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
             <maven.compiler.source>1.8</maven.compiler.source>
             <maven.compiler.target>1.8</maven.compiler.target>
-            <junit.jupiter.version>5.4.0</junit.jupiter.version>
-            <junit.platform.version>1.4.0</junit.platform.version>
-            <jqwik.version>1.1.1</jqwik.version>
-            <assertj-core.version>3.11.1</assertj-core.version>
+            <junit.jupiter.version>5.5.2</junit.jupiter.version>
+            <junit.platform.version>1.5.2</junit.platform.version>
+            <jqwik.version>1.2.1</jqwik.version>
+            <assertj-core.version>3.13.2</assertj-core.version>
             <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         </properties>
 

--- a/java/jqwik/pom.xml
+++ b/java/jqwik/pom.xml
@@ -26,12 +26,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>${junit.jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.jupiter.version}</version>

--- a/java/jqwik/src/test/java/FizzBuzzExamples.java
+++ b/java/jqwik/src/test/java/FizzBuzzExamples.java
@@ -1,8 +1,6 @@
 import net.jqwik.api.*;
 import net.jqwik.api.constraints.IntRange;
 
-import javax.annotation.Generated;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Label("FizzBuzz...")

--- a/java/jqwik/src/test/java/ThingTest.java
+++ b/java/jqwik/src/test/java/ThingTest.java
@@ -1,13 +1,11 @@
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import net.jqwik.api.Example;
+import net.jqwik.api.*;
 
 public class ThingTest {
 
-    @Example
-    void it_should_call_for_action() {
-        Thing thing = new Thing();
-        String value = thing.callForAction();
-        assertEquals("Food", value);
-    }
+	@Example
+	boolean it_should_call_for_action() {
+		Thing thing = new Thing();
+		String value = thing.callForAction();
+		return value.equals("Food");
+	}
 }

--- a/java/junit5/README.md
+++ b/java/junit5/README.md
@@ -16,7 +16,7 @@ Open as preexisting project in your favorite IDE and choose between gradle or ma
 To execute the tests either run `gradle test`, `mvn test` or run the tests from the IDE you are using
 
 ## Test Libraries Available from the Get-Go
-- JUnit 5.3.2
+- JUnit 5.5.2
 
 This repo was tested with eclipse and idea, if you encounter problems please open a issue or send a pull request.
 

--- a/java/junit5/build.gradle
+++ b/java/junit5/build.gradle
@@ -13,6 +13,6 @@ test {
 }
 
 dependencies {
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.3.2")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.2")
+    testCompile("org.junit.jupiter:junit-jupiter-api:5.5.2")
+    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.5.2")
 }

--- a/java/junit5/pom.xml
+++ b/java/junit5/pom.xml
@@ -15,13 +15,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.2</version>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.3.2</version>
+            <version>1.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgraded the following library versions
- junit-platform to 1.5.2
- junit-jupiter to 5.5.2
- jqwik to 1.2.2
- assertJ to 3.13.2

Removed dependencies in java/junit to junit-jupiter and junit-vintage