### PR TITLE
dotnet-core: Bumping versions, cleaning up test-project

### DIFF
--- a/csharp/dotnet-core/Kata.Tests/Kata.Tests.csproj
+++ b/csharp/dotnet-core/Kata.Tests/Kata.Tests.csproj
@@ -2,15 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170222-09" />
-    <PackageReference Include="NSubstitute" Version="2.0.1-rc" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/dotnet-core/Kata.Tests/Kata.Tests.csproj
+++ b/csharp/dotnet-core/Kata.Tests/Kata.Tests.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,17 +15,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\kata\Kata.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0-msbuild3-final" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+	
+	
 </Project>

--- a/csharp/dotnet-core/Kata/Kata.csproj
+++ b/csharp/dotnet-core/Kata/Kata.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>Kata</AssemblyName>
     <RootNamespace>Kata</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
dotnet-core-version wasn't working, bumped all versions to .net 5 (tested on .net5 rc2) and now it works.

While doing this I cleaned up the csproj by removing the project and recreating it with the default xunit test project template (VS2019 preview). 

### What got removed in the cleaning:

"Given that there's no point in packing test projects..."
https://github.com/dotnet/templating/issues/376

"Note that DotNetCliToolReference is now deprecated in favor of .NET Core Local Tools."
https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#dotnetclitoolreference

Magic guid that says "test project"
https://github.com/microsoft/vstest/issues/472
