### PR TITLE
Make pytest tests runnable from VSCode

### DIFF
--- a/python/pytest/README.md
+++ b/python/pytest/README.md
@@ -5,6 +5,9 @@
 
 # Python with pytest
 
+## Recommended Editor
+VSCode + Python extension.
+
 
 ## Installation
 Simply install pytest & pytest-mock :
@@ -36,7 +39,7 @@ pip install -r requirements.txt
  - Write your test in a python file (```test_thing.py``` in the example)
  - run : ```python -m pytest tests/test_thing.py```
  - or if using python >= 3 on a Mac : ```python3 -m pytest tests/test_thing.py```
- - or if using VSCode, right-click any test and select 'Run All Tests'
+ - or if using VSCode, right-click any test and select 'Run All Tests' (select 'pytest' when prompted to configure a test framework)
 
 ## Other
 An alternate version with before fixture is provided in the ```test_thing_fixture.py``` file.

--- a/python/pytest/README.md
+++ b/python/pytest/README.md
@@ -5,9 +5,6 @@
 
 # Python with pytest
 
-## Recommended Editor
-VSCode + Python extension.
-
 
 ## Installation
 Simply install pytest & pytest-mock :
@@ -39,7 +36,7 @@ pip install -r requirements.txt
  - Write your test in a python file (```test_thing.py``` in the example)
  - run : ```python -m pytest tests/test_thing.py```
  - or if using python >= 3 on a Mac : ```python3 -m pytest tests/test_thing.py```
- - or if using VSCode, right-click any test and select 'Run All Tests' (select 'pytest' when prompted to configure a test framework)
+ - or if using VSCode + Python extension, right-click any test and select 'Run All Tests' (select 'pytest' when prompted to configure a test framework)
 
 ## Other
 An alternate version with before fixture is provided in the ```test_thing_fixture.py``` file.


### PR DESCRIPTION
required an __init__ file in the tests directory for vs code integrated test runner to work