### PR TITLE
Update gitignore for IntelliJ

### DIFF
--- a/js/jest-tests/.gitignore
+++ b/js/jest-tests/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log*
 node_modules
 .vscode
 coverage
+.idea/


### PR DESCRIPTION
Noticed this was missing while using the jest sample to start a project in WebStorm