### PR TITLE
Update stack to lts-20.3

### DIFF
--- a/haskell/hspec/fizzbuzz/stack.yaml
+++ b/haskell/hspec/fizzbuzz/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.13
+resolver: lts-20.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/haskell/hspec/helloworld/stack.yaml
+++ b/haskell/hspec/helloworld/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.13
+resolver: lts-20.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Fixes a compile error (tested by running `stack test` on the helloworld folder).

```
ghc: panic! (the 'impossible' happened)
  (GHC version 8.6.4 for x86_64-unknown-linux):
        Prelude.chr: bad argument: 1543503875

Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
```