### PR TITLE
fix junit dependency for java cucumber project

### DIFF
--- a/java/cucumber/pom.xml
+++ b/java/cucumber/pom.xml
@@ -12,13 +12,24 @@
         <cucumber.version>5.1.2</cucumber.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-        <junit-jupiter.version>5.5.2</junit-jupiter.version>
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <junit-platform.version>1.8.1</junit-platform.version>
         <minimum.maven.version>3.6.0</minimum.maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -35,8 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -46,7 +56,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
     <build>
         <plugins>


### PR DESCRIPTION
I was trying out the java/cucumber project and it was not working

```
 mvn verify                                                                                                                  21:51  itbhp@gallifrey
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------------< swkBerlin:cucumber-jvm-junit5 >--------------------
[INFO] Building cucumber-jvm-junit5 1.0.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ cucumber-jvm-junit5 ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Users/itbhp/Documents/Projects/github/itbhp/katas/kata-bootstraps/java/cucumber/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.10.0:compile (default-compile) @ cucumber-jvm-junit5 ---
[INFO] No sources to compile
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ cucumber-jvm-junit5 ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 2 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.10.0:testCompile (default-testCompile) @ cucumber-jvm-junit5 ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ cucumber-jvm-junit5 ---
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ cucumber-jvm-junit5 ---
[WARNING] JAR will be empty - no content was marked for inclusion!
[INFO] Building jar: /Users/itbhp/Documents/Projects/github/itbhp/katas/kata-bootstraps/java/cucumber/target/cucumber-jvm-junit5-1.0.0.jar
[INFO] 
[INFO] --- maven-antrun-plugin:1.8:run (CLI-test) @ cucumber-jvm-junit5 ---
[INFO] Executing tasks

main:
     [echo] Running JUnit Platform CLI
     [java] 
     [java] Thanks for using JUnit! Support its development at https://junit.org/sponsoring
     [java] 
     [java] Exception in thread "main" java.lang.NoClassDefFoundError: org/junit/platform/commons/util/ClassNamePatternFilterUtils
     [java]     at org.junit.platform.launcher.core.LauncherFactory.loadAndFilterTestExecutionListeners(LauncherFactory.java:191)
     [java]     at org.junit.platform.launcher.core.LauncherFactory.registerTestExecutionListeners(LauncherFactory.java:179)
     [java]     at org.junit.platform.launcher.core.LauncherFactory.createDefaultLauncher(LauncherFactory.java:137)
     [java]     at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:125)
     [java]     at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:109)
     [java]     at org.junit.platform.console.tasks.ConsoleTestExecutor.executeTests(ConsoleTestExecutor.java:62)
     [java]     at org.junit.platform.console.tasks.ConsoleTestExecutor.lambda$execute$0(ConsoleTestExecutor.java:58)
     [java]     at org.junit.platform.console.tasks.CustomContextClassLoaderExecutor.invoke(CustomContextClassLoaderExecutor.java:33)
     [java]     at org.junit.platform.console.tasks.ConsoleTestExecutor.execute(ConsoleTestExecutor.java:58)
     [java]     at org.junit.platform.console.ConsoleLauncher.executeTests(ConsoleLauncher.java:95)
     [java]     at org.junit.platform.console.ConsoleLauncher.execute(ConsoleLauncher.java:73)
     [java]     at org.junit.platform.console.ConsoleLauncher.execute(ConsoleLauncher.java:50)
     [java]     at org.junit.platform.console.ConsoleLauncher.execute(ConsoleLauncher.java:43)
     [java]     at org.junit.platform.console.ConsoleLauncher.main(ConsoleLauncher.java:37)
     [java] Caused by: java.lang.ClassNotFoundException: org.junit.platform.commons.util.ClassNamePatternFilterUtils
     [java]     at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
     [java]     at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
     [java]     at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
     [java]     ... 14 more
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.151 s
[INFO] Finished at: 2023-10-12T21:51:50+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (CLI-test) on project cucumber-jvm-junit5: An Ant BuildException has occured: Java returned: 1
[ERROR] around Ant part ...<java newenvironment="true" fork="true" classname="org.junit.platform.console.ConsoleLauncher" maxmemory="512m" failonerror="true" classpathref="maven.test.classpath">... @ 5:170 in /Users/itbhp/Documents/Projects/github/itbhp/katas/kata-bootstraps/java/cucumber/target/antrun/build-main.xml
```

I was using this Java version

```
$ java --version                                                                                                             
openjdk 17.0.5 2022-10-18 LTS
OpenJDK Runtime Environment Corretto-17.0.5.8.1 (build 17.0.5+8-LTS)
OpenJDK 64-Bit Server VM Corretto-17.0.5.8.1 (build 17.0.5+8-LTS, mixed mode, sharing)
```

and this maven version

```
$ mvn -version                                                                                                              
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /Users/itbhp/.sdkman/candidates/maven/current
Java version: 17.0.5, vendor: Amazon.com Inc., runtime: /Users/itbhp/.sdkman/candidates/java/17.0.5-amzn
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "13.5.2", arch: "x86_64", family: "mac"
```